### PR TITLE
fix(statusline): force UTF-8 stdout so it doesn't crash on non-UTF-8 symbols

### DIFF
--- a/.claude/hooks/statusline.py
+++ b/.claude/hooks/statusline.py
@@ -5,7 +5,16 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
+
+# Force UTF-8 stdout so the accent rail (▌), arrow separator (›) and ⚠ marker
+# don't crash print() on consoles whose default encoding isn't UTF-8
+# (e.g. Windows cp1251); errors='replace' as a last-resort safety net.
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
 
 # Traffic-light colors — Claude-branded (warm earth)
 GREEN = "\033[38;2;110;176;90m"    # leaf  #6eb05a
@@ -62,7 +71,7 @@ def main():
 
     # Debug: dump input to file (set DEBUG_STATUSLINE=1)
     if os.getenv("DEBUG_STATUSLINE"):
-        debug_path = Path("/tmp/claude-statusline-debug.json")
+        debug_path = Path(tempfile.gettempdir()) / "claude-statusline-debug.json"
         debug_path.write_text(json.dumps(data, indent=2, default=str))
 
     project_dir = data.get("workspace", {}).get("project_dir", "")


### PR DESCRIPTION
Force UTF-8 stdout so it doesn't crash on non-UTF-8 consoles

The accent rail (U+258C), arrow separator (U+203A) and warning glyph (U+26A0) are non-ASCII. On consoles whose default encoding isn't UTF-8 (e.g. Windows cp1251) print() raised UnicodeEncodeError and the status line failed to render at all. Reconfigure stdout to UTF-8 with errors='replace' at startup so the glyphs print on every platform.

Also write the DEBUG_STATUSLINE dump to the OS temp dir via tempfile.gettempdir() instead of the Unix-only /tmp path, which does not exist on native Windows.